### PR TITLE
Add DISPLAY=:0 to the get socket command

### DIFF
--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -3,7 +3,8 @@ var util         = require('util');
 var EventEmitter = require('events').EventEmitter;
 var Queue        = require('fastqueue');
 
-var GET_SOCKET_PATH_CMD = 'i3 --get-socketpath';
+// Setting DISPLAY lets this command work when ssh'd into the machine
+var GET_SOCKET_PATH_CMD = 'DISPLAY=:0 i3 --get-socketpath';
 var I3_MAGIC     = new Buffer('i3-ipc');
 var I3_MESSAGE_HEADER_LENGTH = I3_MAGIC.length + 8;
 


### PR DESCRIPTION
This library was failing when I was using the node repl over ssh. This fixes that, but may have other problems. Willing to learn more about DISPLAY settings if necessary.