### PR TITLE
I3IpcClient "connect" emit order is corrected.

### DIFF
--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -68,8 +68,9 @@ function I3IpcClient(opts) {
     if (err)
        return self.emit('error', err); 
    
-    self.emit('connect', self);
     self._stream = stream;
+    self.emit('connect', self);
+
     self._pump(); // send queued commands
     self._waitHeader = true;
 


### PR DESCRIPTION
I3IpcClient "connect" event emit is placed after "self._stream" assign.