### PR TITLE
Changed Buffer() to Buffer.from() as per node deprecation warning.

### DIFF
--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -4,7 +4,7 @@ var EventEmitter = require('events').EventEmitter;
 var Queue        = require('fastqueue');
 
 var GET_SOCKET_PATH_CMD = 'i3 --get-socketpath';
-var I3_MAGIC     = new Buffer('i3-ipc');
+var I3_MAGIC     = new Buffer.from('i3-ipc');
 var I3_MESSAGE_HEADER_LENGTH = I3_MAGIC.length + 8;
 
 function createStream(opts, callback) {
@@ -47,7 +47,7 @@ function encodeCommand(code, payload) {
   if (!payload)
     payload = '';
   var payloadOffset = I3_MAGIC.length + 8;
-  var buf = new Buffer(payloadOffset + payload.length);
+  var buf = new Buffer.from(payloadOffset + payload.length);
   I3_MAGIC.copy(buf);
   buf.writeUInt32LE(payload.length, 6);
   buf.writeUInt32LE(code, 10);


### PR DESCRIPTION
(node:14165) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.