### PR TITLE
Fixed missing variable declaration

### DIFF
--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -140,7 +140,7 @@ I3IpcClient.prototype._handleMessage = function() {
   }
 
   if (message.isEvent) {
-     eventName = eventNameFromCode[message.code];
+     var eventName = eventNameFromCode[message.code];
      // TODO: check if code is known
      if (payload instanceof Error)
        return this.emit('error', payload)


### PR DESCRIPTION
I'm using `node-i3` in an electron app that precompiles dependencies with webpack and babel and this  threw a missing variable error after the compilation.