### PR TITLE
Add missing command and event types

### DIFF
--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -121,11 +121,11 @@ I3IpcClient.prototype.message = function(cmd, payload, callback) {
   this._pump();
 }
 
-var commandNameFromCode = "COMMAND GET_WORKSPACES SUBSCRIBE GET_OUTPUTS GET_TREE GET_MARKS GET_BAR_CONFIG GET_VERSION".split(' ');
+var commandNameFromCode = "COMMAND GET_WORKSPACES SUBSCRIBE GET_OUTPUTS GET_TREE GET_MARKS GET_BAR_CONFIG GET_VERSION GET_BINDING_MODES GET_CONFIG SEND_TICK SYNC".split(' ');
 var commandCodeFromName = {};
 commandNameFromCode.forEach(function(name, code) { commandCodeFromName[name] = code; });
 
-var eventNameFromCode = "workspace output mode window barconfig_update binding".split(' ');
+var eventNameFromCode = "workspace output mode window barconfig_update binding shutdown tick".split(' ');
 var eventCodeFromName = {};
 eventNameFromCode.forEach(function(name, code) { eventCodeFromName[name] = code; });
 


### PR DESCRIPTION
Primarily I wanted to use the "shutdown" event to handle reconnecting but it was missing. I added all other newer command and event types as well.