### PR TITLE
measure payload length in utf-8

### DIFF
--- a/lib/ipc.js
+++ b/lib/ipc.js
@@ -47,9 +47,9 @@ function encodeCommand(code, payload) {
   if (!payload)
     payload = '';
   var payloadOffset = I3_MAGIC.length + 8;
-  var buf = new Buffer.alloc(payloadOffset + payload.length);
+  var buf = new Buffer.alloc(payloadOffset + Buffer.byteLength(payload, 'utf-8'));
   I3_MAGIC.copy(buf);
-  buf.writeUInt32LE(payload.length, 6);
+  buf.writeUInt32LE(Buffer.byteLength(payload, 'utf-8'), 6);
   buf.writeUInt32LE(code, 10);
   if (payload.length > 0) {
     buf.write(payload, payloadOffset);


### PR DESCRIPTION
Encountered a problem when using workspaces that contain utf-8 characters in them.
The problem arises from the fact that the payload length is measured in "rune" count, not byte count.

This PR makes use of Buffer.bytesLength in utf-8 (which is the most common encoding in the wild nowadays).

There may be other places where this might need to be applied but I haven't checked.